### PR TITLE
Support passing FormData to zx.parseForm

### DIFF
--- a/src/parsers.test.ts
+++ b/src/parsers.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { zx } from './';
 import type { LoaderArgs } from '@remix-run/node';
 import { FormData, Request } from '@remix-run/node';
 import { z } from 'zod';
+import { zx } from './';
 
 type Params = LoaderArgs['params'];
 
@@ -160,6 +160,13 @@ describe('parseForm', () => {
   test('parses FormData from Request using a schema', async () => {
     const request = createFormRequest();
     const result = await zx.parseForm(request, schema);
+    expect(result).toStrictEqual(formResult);
+    type verify = Expect<Equal<typeof result, Result>>;
+  });
+
+  test('parses FormData from FormData using a schema', async () => {
+    const formData = await createFormRequest().formData();
+    const result = await zx.parseForm(formData, schema);
     expect(result).toStrictEqual(formResult);
     type verify = Expect<Equal<typeof result, Result>>;
   });

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,8 +1,9 @@
-import { z, ZodType } from "zod";
-import type { ZodRawShape, ZodTypeAny } from "zod";
-import type { LoaderArgs } from "@remix-run/node";
+import type { LoaderArgs } from '@remix-run/node';
+import { FormData } from '@remix-run/node';
+import type { ZodRawShape, ZodTypeAny } from 'zod';
+import { z, ZodType } from 'zod';
 
-type Params = LoaderArgs["params"];
+type Params = LoaderArgs['params'];
 
 type Options = {
   /**
@@ -57,8 +58,18 @@ export function parseQuery<T extends ZodRawShape | z.ZodTypeAny>(
  * @param request - A Request
  * @param schema - A Zod object shape or object schema to validate.
  */
-export async function parseForm<T extends ZodRawShape | z.ZodTypeAny>(
+export function parseForm<T extends ZodRawShape | z.ZodTypeAny>(
+  formData: FormData,
+  schema: T,
+  options?: Options
+): Promise<ParsedData<T>>;
+export function parseForm<T extends ZodRawShape | z.ZodTypeAny>(
   request: Request,
+  schema: T,
+  options?: Options
+): Promise<ParsedData<T>>;
+export async function parseForm<T extends ZodRawShape | z.ZodTypeAny>(
+  request: Request | FormData,
   schema: T,
   options?: Options
 ): Promise<ParsedData<T>> {
@@ -81,10 +92,11 @@ type SearchParamsParser = (searchParams: URLSearchParams) => ParsedSearchParams;
  * Get the form data from a request as an object.
  */
 async function parseFormData(
-  request: Request,
+  request: Request | FormData,
   customParser?: SearchParamsParser
 ) {
-  const formData = await request.clone().formData();
+  const formData =
+    request instanceof FormData ? request : await request.clone().formData();
   // @ts-ignore: the types are wrong here. see: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams
   return parseSearchParams(new URLSearchParams(formData), customParser);
 }


### PR DESCRIPTION
If you read the FormData object before calling zx.parseForm it would be useful to be able to pass that FormData object directly.

This can be useful if the form was used to upload files, since you'll have to use [an uploadHandler](https://remix.run/docs/en/v1/api/remix#uploadhandler) and get a FormData object.