### PR TITLE
Fix issue with Locking

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -85,7 +85,7 @@ export function parseQuery<T extends ZodRawShape | ZodTypeAny>(
   try {
     const searchParams = isURLSearchParams(request)
       ? request
-      : getSearchParamsFromRequest(request);
+      : getSearchParamsFromRequest(request.clone());
     const params = parseSearchParams(searchParams, options?.parser);
     const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
     return finalSchema.parse(params);
@@ -107,7 +107,7 @@ export function parseQuerySafe<T extends ZodRawShape | ZodTypeAny>(
 ): SafeParsedData<T> {
   const searchParams = isURLSearchParams(request)
     ? request
-    : getSearchParamsFromRequest(request);
+    : getSearchParamsFromRequest(request.clone());
   const params = parseSearchParams(searchParams, options?.parser);
   const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
   return finalSchema.safeParse(params) as SafeParsedData<T>;
@@ -128,7 +128,9 @@ export async function parseForm<
   options?: Options<Parser>
 ): Promise<ParsedData<T>> {
   try {
-    const formData = isFormData(request) ? request : await request.formData();
+    const formData = isFormData(request)
+      ? request
+      : await request.clone().formData();
     const data = await parseFormData(formData, options?.parser);
     const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
     return finalSchema.parse(data);
@@ -151,7 +153,9 @@ export async function parseFormSafe<
   schema: T,
   options?: Options<Parser>
 ): Promise<SafeParsedData<T>> {
-  const formData = isFormData(request) ? request : await request.formData();
+  const formData = isFormData(request)
+    ? request
+    : await request.clone().formData();
   const data = await parseFormData(formData, options?.parser);
   const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
   return finalSchema.safeParse(data) as SafeParsedData<T>;

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,5 +1,3 @@
-import { z, ZodType } from 'zod';
-import { createErrorResponse } from './errors';
 import type { LoaderArgs } from '@remix-run/server-runtime';
 import type {
   output,
@@ -8,6 +6,8 @@ import type {
   ZodRawShape,
   ZodTypeAny,
 } from 'zod';
+import { z, ZodType } from 'zod';
+import { createErrorResponse } from './errors';
 
 type Params = LoaderArgs['params'];
 
@@ -85,7 +85,7 @@ export function parseQuery<T extends ZodRawShape | ZodTypeAny>(
   try {
     const searchParams = isURLSearchParams(request)
       ? request
-      : getSearchParamsFromRequest(request.clone());
+      : getSearchParamsFromRequest(request);
     const params = parseSearchParams(searchParams, options?.parser);
     const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
     return finalSchema.parse(params);
@@ -107,7 +107,7 @@ export function parseQuerySafe<T extends ZodRawShape | ZodTypeAny>(
 ): SafeParsedData<T> {
   const searchParams = isURLSearchParams(request)
     ? request
-    : getSearchParamsFromRequest(request.clone());
+    : getSearchParamsFromRequest(request);
   const params = parseSearchParams(searchParams, options?.parser);
   const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
   return finalSchema.safeParse(params) as SafeParsedData<T>;

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,3 +1,5 @@
+import { z, ZodType } from 'zod';
+import { createErrorResponse } from './errors';
 import type { LoaderArgs } from '@remix-run/server-runtime';
 import type {
   output,
@@ -6,8 +8,6 @@ import type {
   ZodRawShape,
   ZodTypeAny,
 } from 'zod';
-import { z, ZodType } from 'zod';
-import { createErrorResponse } from './errors';
 
 type Params = LoaderArgs['params'];
 


### PR DESCRIPTION
Was using the package along with another that needed access to the request form data and was getting an error that the request was being locked, and wouldn't be able to complete the request because of this.

Made changes where it will now clone the request and do the parsing on that request instead of the actual request to then forward it onto other packages.