### PR TITLE
Infer type of `ZodEffects` schemas using `zx.parseFormSafe`

### DIFF
--- a/src/parsers.test.ts
+++ b/src/parsers.test.ts
@@ -420,20 +420,21 @@ describe('parseFormSafe', () => {
     type verify = Expect<Equal<typeof result.data, Result>>;
   });
 
-  test('infer type of ZodEffect schemas', async () => {
+  test('parses FormData from FormData using a ZodEffects schema', async () => {
     const schema = z
       .object({
         password: z.string().min(8),
         confirmPassword: z.string().min(8),
       })
       .refine(({ password, confirmPassword }) => password === confirmPassword);
-    const formData = new FormData();
-    formData.set('password', 'foo');
-    formData.set('confirmPassword', 'bar');
     const data = {
       password: 'foo',
       confirmPassword: 'bar ',
     };
+    const formData = new FormData();
+    Object.entries(data).forEach(([key, value]) => {
+      formData.set(key, value);
+    });
     const zodixResult = await zx.parseFormSafe(formData, schema);
     const zodResult = await schema.safeParseAsync(data);
     expect(zodixResult).toStrictEqual(zodResult);

--- a/src/parsers.test.ts
+++ b/src/parsers.test.ts
@@ -419,6 +419,26 @@ describe('parseFormSafe', () => {
     });
     type verify = Expect<Equal<typeof result.data, Result>>;
   });
+
+  test('infer type of ZodEffect schemas', async () => {
+    const schema = z
+      .object({
+        password: z.string().min(8),
+        confirmPassword: z.string().min(8),
+      })
+      .refine(({ password, confirmPassword }) => password === confirmPassword);
+    const formData = new FormData();
+    formData.set('password', 'foo');
+    formData.set('confirmPassword', 'bar');
+    const data = {
+      password: 'foo',
+      confirmPassword: 'bar ',
+    };
+    const zodixResult = await zx.parseFormSafe(formData, schema);
+    const zodResult = await schema.safeParseAsync(data);
+    expect(zodixResult).toStrictEqual(zodResult);
+    type verify = Expect<Equal<typeof zodixResult, typeof zodResult>>;
+  });
 });
 
 // Custom URLSearchParams parser that cleans arr[] keys

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -33,7 +33,7 @@ type ParsedData<T extends ZodRawShape | ZodTypeAny> = T extends ZodTypeAny
  * Generic return type for parseXSafe functions.
  */
 type SafeParsedData<T extends ZodRawShape | ZodTypeAny> = T extends ZodTypeAny
-  ? SafeParseReturnType<T, ParsedData<T>>
+  ? SafeParseReturnType<z.infer<T>, ParsedData<T>>
   : T extends ZodRawShape
   ? SafeParseReturnType<ZodObject<T>, ParsedData<T>>
   : never;


### PR DESCRIPTION
`zx.parseFormSafe` is able to parse `ZodEffects` schemas but it fails to infer the types.
I added a failing test to reproduce issue #17 but I wasn't able to fix it instantly so I will leave it there for now. 
I will look into it next week probably.

@rileytomasek I did not dig into `zod` typings so far, do you have any idea how to handle this?

EDIT: I found a way to fix the type inference of result.error when user is parsing a `ZodEffects` schema with `zx.parsFormSafe`.

Fixes #17 