### PR TITLE
feat: Support asynchronous schema parsing

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -131,7 +131,7 @@ export async function parseForm<
     const formData = isFormData(request) ? request : await request.formData();
     const data = await parseFormData(formData, options?.parser);
     const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
-    return finalSchema.parse(data);
+    return finalSchema.parseAsync(data);
   } catch (error) {
     throw createErrorResponse(options);
   }
@@ -154,7 +154,7 @@ export async function parseFormSafe<
   const formData = isFormData(request) ? request : await request.formData();
   const data = await parseFormData(formData, options?.parser);
   const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
-  return finalSchema.safeParse(data) as SafeParsedData<T>;
+  return finalSchema.safeParseAsync(data) as Promise<SafeParsedData<T>>;
 }
 
 /**
@@ -179,10 +179,7 @@ function isObjectEntry([, value]: [string, FormDataEntryValue]) {
 /**
  * Get the form data from a request as an object.
  */
-async function parseFormData(
-  formData: FormData,
-  customParser?: SearchParamsParser
-) {
+function parseFormData(formData: FormData, customParser?: SearchParamsParser) {
   const objectEntries = [...formData.entries()].filter(isObjectEntry);
   objectEntries.forEach(([key, value]) => {
     formData.set(key, JSON.stringify(value));


### PR DESCRIPTION
Here is my proposal to support asynchronous schema parsing. 

⚠️ This proposal introduces breaking changes, i.e. all `zx.parseXXX` methods are now asynchronous.

@rileytomasek Let me know if you're okay with this change or if you'd rather add asynchronous methods to `zodix`.

Fixes #19 