### PR TITLE
fix: exclude @remix-run/server-runtime from external deps to reduce bundle size

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,7 +1,7 @@
 require('esbuild').buildSync({
   bundle: true,
   entryPoints: ['src/index.ts'],
-  external: ['zod'],
+  external: ['zod', '@remix-run/server-runtime'],
   outfile: 'dist/index.js',
   platform: 'node',
   target: ['node16'],


### PR DESCRIPTION
Hi!
_zodix is a great work! thank you very much 🙏_

with the current build configuration, the size of the dist/index.js file was 258kb because the `@remix-run/server-runtime` and its dependencies were included in the bundle file.

https://unpkg.com/browse/zodix@0.4.0/dist/
![image](https://user-images.githubusercontent.com/1294640/211491394-13db33cf-06a8-456a-ab4d-d3470015da95.png)



I have added the `@remix-run/server-runtime` package as an external package.

The file size has reduced to ~8kB.

```
❯ du -h dist/index.js 
8.0K    dist/index.js
```




