### PR TITLE
Provide an alternative mechanism for checking ZodType in parsers

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -39,6 +39,14 @@ type SafeParsedData<T extends ZodRawShape | ZodTypeAny> = T extends ZodTypeAny
   : never;
 
 /**
+ * A Type Guard to check object is a ZodType.
+ * `instanceof` is not always reliable when bundled.
+ * `parse` is the only method we require to determine it is a Zod object.
+ */
+const isZodType = (input: ZodRawShape | ZodTypeAny): input is ZodType =>
+  typeof input.parse === 'function';
+
+/**
  * Parse and validate Params from LoaderArgs or ActionArgs. Throws an error if validation fails.
  * @param params - A Remix Params object.
  * @param schema - A Zod object shape or object schema to validate.
@@ -50,7 +58,7 @@ export function parseParams<T extends ZodRawShape | ZodTypeAny>(
   options?: Options
 ): ParsedData<T> {
   try {
-    const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
+    const finalSchema = isZodType(schema) ? schema : z.object(schema);
     return finalSchema.parse(params);
   } catch (error) {
     throw createErrorResponse(options);
@@ -67,7 +75,7 @@ export function parseParamsSafe<T extends ZodRawShape | ZodTypeAny>(
   params: Params,
   schema: T
 ): SafeParsedData<T> {
-  const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
+  const finalSchema = isZodType(schema) ? schema : z.object(schema);
   return finalSchema.safeParse(params) as SafeParsedData<T>;
 }
 
@@ -87,7 +95,7 @@ export function parseQuery<T extends ZodRawShape | ZodTypeAny>(
       ? request
       : getSearchParamsFromRequest(request);
     const params = parseSearchParams(searchParams, options?.parser);
-    const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
+    const finalSchema = isZodType(schema) ? schema : z.object(schema);
     return finalSchema.parse(params);
   } catch (error) {
     throw createErrorResponse(options);
@@ -109,7 +117,7 @@ export function parseQuerySafe<T extends ZodRawShape | ZodTypeAny>(
     ? request
     : getSearchParamsFromRequest(request);
   const params = parseSearchParams(searchParams, options?.parser);
-  const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
+  const finalSchema = isZodType(schema) ? schema : z.object(schema);
   return finalSchema.safeParse(params) as SafeParsedData<T>;
 }
 
@@ -132,7 +140,7 @@ export async function parseForm<
       ? request
       : await request.clone().formData();
     const data = await parseFormData(formData, options?.parser);
-    const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
+    const finalSchema = isZodType(schema) ? schema : z.object(schema);
     return finalSchema.parseAsync(data);
   } catch (error) {
     throw createErrorResponse(options);
@@ -157,7 +165,7 @@ export async function parseFormSafe<
     ? request
     : await request.clone().formData();
   const data = await parseFormData(formData, options?.parser);
-  const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
+  const finalSchema = isZodType(schema) ? schema : z.object(schema);
   return finalSchema.safeParseAsync(data) as Promise<SafeParsedData<T>>;
 }
 


### PR DESCRIPTION
Hi! 👋 
      
Firstly, thanks for your work on this project! 🙂

**Issue**

This original issue - https://github.com/rileytomasek/zodix/issues/12

Testing Remix Loaders with Vitest sometimes produces the following error:

`TypeError: keyValidator._parse is not a function`

The issue appears to be a result of using `instanceof` to check an object is of a `ZodType` class. However, during a Vitest build this class is duplicated, meaning `instanceof` is performed against a unrelated class. (An explanation of this can be found in the comments for the original issue).

**Proposal**

This PR implements the proposed solution from @taternz https://github.com/rileytomasek/zodix/issues/12#issuecomment-1409662038, providing an alternative way to check for an object is an instance of the ZodType class.

Obviously this is only a very superficial check to see that the object we receive contains a `parse` method. An alternative could be to do a shallow comparison of the `Object.keys` to determine object equality?