### PR TITLE
New type assertion function, largely from current GH Issues

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,4 +1,4 @@
-import { z, ZodType } from 'zod';
+import { z } from 'zod';
 import { createErrorResponse } from './errors';
 import type { LoaderArgs } from '@remix-run/server-runtime';
 import type {
@@ -19,6 +19,14 @@ type Options<Parser = SearchParamsParser> = {
   /** Custom URLSearchParams parsing function. */
   parser?: Parser;
 };
+
+/**
+ * Type assertion function avoids problems with some bundlers when
+ * using `instanceof` to check the type of a `schema` param.
+ */
+const isZodType = (input: ZodRawShape | ZodTypeAny): input is ZodTypeAny => {
+  return typeof input._parse === 'function';
+}
 
 /**
  * Generic return type for parseX functions.
@@ -50,7 +58,7 @@ export function parseParams<T extends ZodRawShape | ZodTypeAny>(
   options?: Options
 ): ParsedData<T> {
   try {
-    const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
+    const finalSchema = isZodType(schema) ? schema : z.object(schema);
     return finalSchema.parse(params);
   } catch (error) {
     throw createErrorResponse(options);
@@ -67,7 +75,7 @@ export function parseParamsSafe<T extends ZodRawShape | ZodTypeAny>(
   params: Params,
   schema: T
 ): SafeParsedData<T> {
-  const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
+  const finalSchema = isZodType(schema) ? schema : z.object(schema);
   return finalSchema.safeParse(params) as SafeParsedData<T>;
 }
 
@@ -87,7 +95,7 @@ export function parseQuery<T extends ZodRawShape | ZodTypeAny>(
       ? request
       : getSearchParamsFromRequest(request);
     const params = parseSearchParams(searchParams, options?.parser);
-    const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
+    const finalSchema = isZodType(schema) ? schema : z.object(schema);
     return finalSchema.parse(params);
   } catch (error) {
     throw createErrorResponse(options);
@@ -109,7 +117,7 @@ export function parseQuerySafe<T extends ZodRawShape | ZodTypeAny>(
     ? request
     : getSearchParamsFromRequest(request);
   const params = parseSearchParams(searchParams, options?.parser);
-  const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
+  const finalSchema = isZodType(schema) ? schema : z.object(schema);
   return finalSchema.safeParse(params) as SafeParsedData<T>;
 }
 
@@ -132,7 +140,7 @@ export async function parseForm<
       ? request
       : await request.clone().formData();
     const data = await parseFormData(formData, options?.parser);
-    const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
+    const finalSchema = isZodType(schema) ? schema : z.object(schema);
     return finalSchema.parseAsync(data);
   } catch (error) {
     throw createErrorResponse(options);
@@ -157,7 +165,7 @@ export async function parseFormSafe<
     ? request
     : await request.clone().formData();
   const data = await parseFormData(formData, options?.parser);
-  const finalSchema = schema instanceof ZodType ? schema : z.object(schema);
+  const finalSchema = isZodType(schema) ? schema : z.object(schema);
   return finalSchema.safeParseAsync(data) as Promise<SafeParsedData<T>>;
 }
 

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -25,7 +25,7 @@ type Options<Parser = SearchParamsParser> = {
  * using `instanceof` to check the type of a `schema` param.
  */
 const isZodType = (input: ZodRawShape | ZodTypeAny): input is ZodTypeAny => {
-  return typeof input._parse === 'function';
+  return typeof input.parse === 'function';
 }
 
 /**


### PR DESCRIPTION
Hi @rileytomasek . 

Really like Zodix, but I'm having a problem with this now classic issue: 

[[BUG] TypeError: keyValidator._parse is not a function](https://github.com/rileytomasek/zodix/issues/12)

I saw a type assertion proposed at one point, but the PR was eventually closed without merging. I've updated it and am re-proposing it. I changed the `is` type, as the original made TypeScript scream. I know you mentioned not loving this resolution, I'm not really sure why, but I did ask in the Zod Discord for ideas generally. No takers. 

I _think_ this'll work and I'd rather push it here than copy Zodix into my project (Remix 1.12). 

I think I've updated all your various parse functions. The tests pass. Does this suit?

(Or did I miss something amiss with the original PR that I've replicated?)

-j