### PR TITLE
fix: change LoaderArgs to DataFunctionArgs to support Remix V2

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { createErrorResponse } from './errors';
-import type { LoaderArgs } from '@remix-run/server-runtime';
+import type { DataFunctionArgs } from '@remix-run/server-runtime';
 import type {
   output,
   SafeParseReturnType,
@@ -9,7 +9,7 @@ import type {
   ZodTypeAny,
 } from 'zod';
 
-type Params = LoaderArgs['params'];
+type Params = DataFunctionArgs['params'];
 
 type Options<Parser = SearchParamsParser> = {
   /** Custom error message for when the validation fails. */


### PR DESCRIPTION
This PR addresses [[BUG]: Typescript compilation fails in Remix V2 #37](https://github.com/rileytomasek/zodix/issues/37)
allowing Typescript to compile Remix V2 projects with Zodix.

See linked issue for details, but TLDR is that LoaderArgs was renamed LoaderFunctionArgs in Remix V2. Since LoaderArgs/ActionArgs in V1 and LoaderFunctionArgs/ActionFunctionArgs in V2 are just aliases for DataFunctionArgs in both V1 and V2, we can fix this issue by simply swapping out the LoaderArgs references for DataFunctionArgs.