### PR TITLE
fix: add 2.x to @remix-run/server-runtime peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "zod": "^3.19.1"
   },
   "peerDependencies": {
-    "@remix-run/server-runtime": "1.x",
+    "@remix-run/server-runtime": "1.x || 2.x",
     "zod": "3.x"
   },
   "publishConfig": {


### PR DESCRIPTION
Updates the @remix-run/server-runtime peer dependency from "1.x" to "1.x || 2.x" for Remix v2 compatibility as outlined in  [BUG: @remix-run/server-runtime peer dependency not compatible with remix v2](https://github.com/rileytomasek/zodix/issues/39).